### PR TITLE
New tests for JBPM Workitem Camel in FUSE (SQL, XSLT, STREAM endpoints)

### DIFF
--- a/release/karaf/itests/camel/README
+++ b/release/karaf/itests/camel/README
@@ -6,6 +6,8 @@ or karaf like container (for example JBoss FUSE).
 karaf.dist.file - path to karaf distribution file (if not defined, the default karaf is downloaded from maven central)
 karaf.keep.runtime.folder - keep pax exam runtime folder after the test execution is finished
 karaf.maxpermsize - increase the maximal size of PermGen space for karaf container in Java 7
+karaf.debug.port - Specify port for remote debugger. If this property is defined, the remote debugger
+                   can be attached to the specified port.
 karaf.install.camel - Some Karaf based containers (for example JBoss Fuse) have Camel
                       already installed. For these containers set
                       value of this property to false. (Default value is true).

--- a/release/karaf/itests/camel/pom.xml
+++ b/release/karaf/itests/camel/pom.xml
@@ -133,6 +133,12 @@
             <scope>test</scope>
             <type>jar</type>
         </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     
     <build>

--- a/release/karaf/itests/camel/src/test/java/org/jboss/integration/fuse/karaf/itest/FeatureConstants.java
+++ b/release/karaf/itests/camel/src/test/java/org/jboss/integration/fuse/karaf/itest/FeatureConstants.java
@@ -14,10 +14,15 @@
 package org.jboss.integration.fuse.karaf.itest;
 
 public class FeatureConstants {
+
+    public static final String KARAF_FEATURES_CONFIG_FILE = "etc/org.apache.karaf.features.cfg";
+    public static final String KARAF_BOOT_FEATURES_KEY = "featuresBoot";
     
     public static final String CAMEL_FEATURE_GROUP_ID = "org.apache.camel.karaf";
     public static final String CAMEL_FEATURE_ARTIFACT_ID = "apache-camel";
     public static final String CAMEL_FEATURE_NAME = "camel";
+    public static final String CAMEL_FEATURE_SQL_NAME = "camel-sql";
+    public static final String CAMEL_FEATURE_STREAM_NAME = "camel-stream";
 
     public static final String DROOLS_FEATURE_GROUP_ID = "org.drools";
     public static final String DROOLS_FEATURE_ARTIFACT_ID = "drools-karaf-features";

--- a/release/karaf/itests/camel/src/test/java/org/jboss/integration/fuse/karaf/itest/workitem/CamelSQLTest.java
+++ b/release/karaf/itests/camel/src/test/java/org/jboss/integration/fuse/karaf/itest/workitem/CamelSQLTest.java
@@ -1,0 +1,105 @@
+package org.jboss.integration.fuse.karaf.itest.workitem;
+
+import org.apache.camel.CamelContext;
+import org.h2.jdbcx.JdbcDataSource;
+import org.jboss.integration.fuse.karaf.itest.KarafConfigUtil;
+import org.jbpm.process.workitem.camel.CamelHandler;
+import org.jbpm.process.workitem.camel.request.RequestPayloadMapper;
+import org.jbpm.process.workitem.camel.response.ResponsePayloadMapper;
+import org.jbpm.process.workitem.camel.uri.SQLURIMapper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.api.KieServices;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.process.ProcessInstance;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import javax.inject.Inject;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class CamelSQLTest {
+
+    private KieServices kieServices;
+    private KieSession kieSession;
+
+    @Inject
+    CamelContext camelContext;
+
+    @Configuration
+    public static Option[] configure() {
+        return KarafConfigUtil.karafConfiguration();
+    }
+
+    @Before
+    public void prepare() {
+        this.kieServices = KieServices.Factory.get();
+        final KieContainer kieContainer = this.kieServices.newKieClasspathContainer(this.getClass().getClassLoader());
+        this.kieSession = kieContainer.newKieSession("camel-workitem-ksession");
+        assertNotNull(this.kieSession);
+    }
+
+    @Test
+    public void testSingleSQLProcess() throws Exception {
+
+        JdbcDataSource dataSource = (JdbcDataSource) camelContext.getRegistry().lookupByName("dataSource");
+        Connection connection = dataSource.getConnection();
+
+        try {
+            // Prepare database table
+            PreparedStatement statement = connection.prepareStatement("CREATE TABLE test (KEY VARCHAR(255), VALUE INTEGER)");
+            statement.execute();
+            // Create row in row in database table
+            statement = connection.prepareStatement("INSERT INTO test VALUES ('myKey',5)");
+            statement.execute();
+
+            // Verify the value was correctly set
+            statement = connection.prepareStatement("SELECT * FROM test WHERE KEY = 'myKey'");
+            ResultSet resultSet = statement.executeQuery();
+            resultSet.next();
+            int value = resultSet.getInt("VALUE");
+            assertTrue(value == 5);
+
+            // Change the value in table using workitem camel
+            CamelHandler handler = new CamelHandler(new SQLURIMapper(), new RequestPayloadMapper("payload"), new ResponsePayloadMapper(), camelContext);
+            kieSession.getWorkItemManager().registerWorkItemHandler("CamelSQL", handler);
+
+            Map<String, Object> params = new HashMap<String, Object>();
+            params.put("dataSourceVar", "dataSource");
+            params.put("queryVar", "UPDATE test SET VALUE = 6 WHERE KEY='myKey'");
+
+            ProcessInstance pi = kieSession.startProcess("CamelSQLProcess", params);
+            ProcessInstance result = kieSession.getProcessInstance(pi.getId());
+
+            // Verify the value was changed
+            resultSet = statement.executeQuery();
+            resultSet.next();
+            value = resultSet.getInt("VALUE");
+            assertTrue(value == 6);
+        } finally {
+            connection.close();
+        }
+    }
+
+    @After
+    public void cleanup() {
+        if (this.kieSession != null) {
+            this.kieSession.dispose();
+        }
+    }
+}

--- a/release/karaf/itests/camel/src/test/java/org/jboss/integration/fuse/karaf/itest/workitem/CamelStreamTest.java
+++ b/release/karaf/itests/camel/src/test/java/org/jboss/integration/fuse/karaf/itest/workitem/CamelStreamTest.java
@@ -1,0 +1,112 @@
+package org.jboss.integration.fuse.karaf.itest.workitem;
+
+import org.apache.camel.CamelContext;
+import org.apache.commons.io.FileUtils;
+import org.jboss.integration.fuse.karaf.itest.KarafConfigUtil;
+import org.jbpm.process.workitem.camel.CamelHandler;
+import org.jbpm.process.workitem.camel.request.RequestPayloadMapper;
+import org.jbpm.process.workitem.camel.response.ResponsePayloadMapper;
+import org.jbpm.process.workitem.camel.uri.GenericURIMapper;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.api.KieServices;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.process.ProcessInstance;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by jpetrlik on 9/9/15.
+ */
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class CamelStreamTest {
+
+    @Inject
+    CamelContext camelContext;
+
+    private KieServices kieServices;
+    private KieSession kieSession;
+
+    private static File testDir;
+    private static File testFile;
+
+    private static final String TEST_DATA = "test-data";
+    private static final String PREFIX_TEST_DIR = "test_dir_";
+    private static final String PREFIX_TEST_FILE = "test_file_";
+
+    @Configuration
+    public static Option[] configure() {
+        return KarafConfigUtil.karafConfiguration();
+    }
+
+    @BeforeClass
+    public static void initialize() {
+        File tempDir = new File(System.getProperty("java.io.tmpdir"));
+        testDir = new File(tempDir, PREFIX_TEST_DIR + UUID.randomUUID().toString());
+        testDir.mkdir();
+        String fileName = PREFIX_TEST_FILE + CamelFileTest.class.getName() + ".txt";
+        testFile = new File(testDir, fileName);
+    }
+
+    @Before
+    public void prepare() {
+        this.kieServices = KieServices.Factory.get();
+        final KieContainer kieContainer = this.kieServices.newKieClasspathContainer(this.getClass().getClassLoader());
+        this.kieSession = kieContainer.newKieSession("camel-workitem-ksession");
+        assertNotNull(this.kieSession);
+    }
+
+    @Test
+    public void testSingleStreamProcess() throws Exception {
+
+        CamelHandler handler = new CamelHandler(new GenericURIMapper("stream"), new RequestPayloadMapper("payload"), new ResponsePayloadMapper(), camelContext);
+        kieSession.getWorkItemManager().registerWorkItemHandler("CamelStream", handler);
+
+        // Write into the file using Camel stream
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("payloadVar", TEST_DATA);
+        params.put("pathVar", "file");
+        params.put("fileNameVar", testFile.getAbsolutePath());
+
+        ProcessInstance pi = kieSession.startProcess("camelStreamProcess", params);
+        ProcessInstance result = kieSession.getProcessInstance(pi.getId());
+        assertNull(result);
+
+        // Verify the output file exists and has correct content
+        assertTrue(testFile.exists());
+        String resultText = FileUtils.readFileToString(testFile);
+        assertTrue(resultText.contains(TEST_DATA));
+    }
+
+    @After
+    public void cleanup() {
+        if (this.kieSession != null) {
+            this.kieSession.dispose();
+        }
+    }
+
+    @AfterClass
+    public static void clean() throws IOException {
+        FileUtils.deleteDirectory(testDir);
+    }
+}

--- a/release/karaf/itests/camel/src/test/java/org/jboss/integration/fuse/karaf/itest/workitem/CamelXSLTTest.java
+++ b/release/karaf/itests/camel/src/test/java/org/jboss/integration/fuse/karaf/itest/workitem/CamelXSLTTest.java
@@ -1,0 +1,131 @@
+package org.jboss.integration.fuse.karaf.itest.workitem;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.jboss.integration.fuse.karaf.itest.KarafConfigUtil;
+import org.jbpm.process.workitem.camel.CamelHandler;
+import org.jbpm.process.workitem.camel.request.RequestPayloadMapper;
+import org.jbpm.process.workitem.camel.uri.XSLTURIMapper;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.api.KieServices;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.process.ProcessInstance;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by jiripetrlik@gmail.com on 9/7/15.
+ *
+ */
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class CamelXSLTTest {
+
+    private KieServices kieServices;
+    private KieSession kieSession;
+
+    private static File testDir;
+    private static File xslFile;
+    private static File outputFile;
+
+    private static final String XML_FILE = "org/jboss/integration/fuse/karaf/itest/example.xml";
+    private static final String XSL_FILE = "org/jboss/integration/fuse/karaf/itest/transform.xsl";
+
+    private static final String HEADER_KEY_XSLT_OUTPUT_FILE = "CamelXsltFileName";
+    private static final String PREFIX_TEST_DIR = "test_dir_";
+    private static final String PREFIX_TRANSFORM_FILE = "transform_";
+    private static final String PREFIX_OUTPUT_FILE = "output_";
+
+    private static final String TRANSFORMED_ELEMENT = "<transformedElement>";
+
+    @Configuration
+    public static Option[] configure() {
+        return KarafConfigUtil.karafConfiguration();
+    }
+
+    @BeforeClass
+    public static void initialize() {
+        String randomUUID = UUID.randomUUID().toString();
+
+        File tempDir = new File(System.getProperty("java.io.tmpdir"));
+        testDir = new File(tempDir, PREFIX_TEST_DIR + randomUUID);
+        testDir.mkdir();
+
+        String fileName = PREFIX_TRANSFORM_FILE + CamelFileTest.class.getName() + ".xsl";
+        xslFile = new File(testDir, fileName);
+
+        fileName = PREFIX_OUTPUT_FILE + CamelFileTest.class.getName() + ".xml";
+        outputFile = new File(testDir, fileName);
+    }
+
+    @Before
+    public void prepare() {
+        this.kieServices = KieServices.Factory.get();
+        final KieContainer kieContainer = this.kieServices.newKieClasspathContainer(this.getClass().getClassLoader());
+        this.kieSession = kieContainer.newKieSession("camel-workitem-ksession");
+        assertNotNull(this.kieSession);
+    }
+
+    @Test
+    public void testSingleXSLTProcess() throws IOException {
+
+        // Load input example into the string
+        String inputXML = IOUtils.toString(this.getClass().getClassLoader().getResourceAsStream(XML_FILE));
+        // Copy XSL file into the temp directory
+        FileUtils.copyInputStreamToFile(this.getClass().getClassLoader().getResourceAsStream(XSL_FILE), xslFile);
+
+        Set<String> headers = new HashSet<String>();
+        headers.add(HEADER_KEY_XSLT_OUTPUT_FILE); // header under this key defines output files
+        CamelHandler handler = new CamelHandler(new XSLTURIMapper(), new RequestPayloadMapper("payload", headers));
+        kieSession.getWorkItemManager().registerWorkItemHandler("CamelXSLT", handler);
+
+        // Run XSLT transformation
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("templateNameVar", "file:///" + xslFile.getAbsolutePath());
+        params.put("payloadVar", inputXML);
+        params.put("outputFileVar", outputFile.getAbsolutePath());
+        params.put("outputVar", "file");
+
+        ProcessInstance pi = kieSession.startProcess("camelXSLTProcess", params);
+        ProcessInstance result = kieSession.getProcessInstance(pi.getId());
+
+        // Verify the output file exists and was successfully processed by XSLT transformations
+        assertTrue(outputFile.exists());
+        // After the running of XSLT transformation, the output file should contain TRANSFORMED_ELEMENT
+        String outputXML = FileUtils.readFileToString(outputFile,"UTF-8");
+        assertTrue(outputXML.contains(TRANSFORMED_ELEMENT));
+    }
+
+    @After
+    public void cleanup() {
+        if (this.kieSession != null) {
+            this.kieSession.dispose();
+        }
+    }
+
+    @AfterClass
+    public static void clean() throws IOException {
+        FileUtils.deleteDirectory(testDir);
+    }
+}

--- a/release/karaf/itests/camel/src/test/resources/OSGI-INF/blueprint/camel-context.xml
+++ b/release/karaf/itests/camel/src/test/resources/OSGI-INF/blueprint/camel-context.xml
@@ -67,6 +67,14 @@
             <bean method="insertAndFireAll" ref="droolsCommandHelper"/>
             <to uri="kie:example-command-ksession?action=execute"/>
         </route>
+
+
     </camelContext>
+
+    <bean id="dataSource" class="org.h2.jdbcx.JdbcDataSource">
+        <property name="URL" value="jdbc:h2:mem:db1"/>
+        <property name="user" value="sa"/>
+        <property name="password" value="sa"/>
+    </bean>
 
 </blueprint>

--- a/release/karaf/itests/camel/src/test/resources/org/jboss/integration/fuse/karaf/itest/example.xml
+++ b/release/karaf/itests/camel/src/test/resources/org/jboss/integration/fuse/karaf/itest/example.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Element>
+    Lorem ipsum....
+</Element>

--- a/release/karaf/itests/camel/src/test/resources/org/jboss/integration/fuse/karaf/itest/transform.xsl
+++ b/release/karaf/itests/camel/src/test/resources/org/jboss/integration/fuse/karaf/itest/transform.xsl
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:template match="/">
+        <transformedElement>
+            <xsl:value-of select="/"/>
+        </transformedElement>
+    </xsl:template>
+</xsl:stylesheet>

--- a/release/karaf/itests/camel/src/test/resources/org/jboss/integration/fuse/karaf/itest/workitem/BPMN2-CamelSQLProcess.bpmn2
+++ b/release/karaf/itests/camel/src/test/resources/org/jboss/integration/fuse/karaf/itest/workitem/BPMN2-CamelSQLProcess.bpmn2
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_2iKicFYwEeWH_vp83kDU0A" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="_dataSourceVarItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_queryVarItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__FD9F61FE-A2D0-43EF-84CD-4D1EDBE500B6_queryInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__FD9F61FE-A2D0-43EF-84CD-4D1EDBE500B6_dataSourceInputXItem" structureRef="String"/>
+  <bpmn2:process id="CamelSQLProcess" drools:packageName="org.jbpm" drools:version="1.0" name="CamelSQLProcess" isExecutable="true">
+    <bpmn2:property id="dataSourceVar" itemSubjectRef="_dataSourceVarItem"/>
+    <bpmn2:property id="queryVar" itemSubjectRef="_queryVarItem"/>
+    <bpmn2:startEvent id="processStartEvent" drools:bgcolor="#9acd32" drools:selectable="true" name="">
+      <bpmn2:outgoing>_C63C8F09-1E36-4793-BF76-8E226AFF3268</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:task id="_FD9F61FE-A2D0-43EF-84CD-4D1EDBE500B6" drools:selectable="true" drools:taskName="CamelSQL"  name="SQL">
+      <bpmn2:incoming>_C63C8F09-1E36-4793-BF76-8E226AFF3268</bpmn2:incoming>
+      <bpmn2:outgoing>_A008622B-217A-4109-91BF-2D879AD07903</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_2iKicVYwEeWH_vp83kDU0A">
+        <bpmn2:dataInput id="_FD9F61FE-A2D0-43EF-84CD-4D1EDBE500B6_queryInputX" drools:dtype="String" itemSubjectRef="__FD9F61FE-A2D0-43EF-84CD-4D1EDBE500B6_queryInputXItem" name="query"/>
+        <bpmn2:dataInput id="_FD9F61FE-A2D0-43EF-84CD-4D1EDBE500B6_dataSourceInputX" drools:dtype="String" itemSubjectRef="__FD9F61FE-A2D0-43EF-84CD-4D1EDBE500B6_dataSourceInputXItem" name="dataSource"/>
+        <bpmn2:inputSet id="_2iKiclYwEeWH_vp83kDU0A">
+          <bpmn2:dataInputRefs>_FD9F61FE-A2D0-43EF-84CD-4D1EDBE500B6_queryInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_FD9F61FE-A2D0-43EF-84CD-4D1EDBE500B6_dataSourceInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_2iKic1YwEeWH_vp83kDU0A"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_2iKidFYwEeWH_vp83kDU0A">
+        <bpmn2:sourceRef>dataSourceVar</bpmn2:sourceRef>
+        <bpmn2:targetRef>_FD9F61FE-A2D0-43EF-84CD-4D1EDBE500B6_dataSourceInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_2iKidVYwEeWH_vp83kDU0A">
+        <bpmn2:sourceRef>queryVar</bpmn2:sourceRef>
+        <bpmn2:targetRef>_FD9F61FE-A2D0-43EF-84CD-4D1EDBE500B6_queryInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:task>
+    <bpmn2:sequenceFlow id="_C63C8F09-1E36-4793-BF76-8E226AFF3268" drools:bgcolor="#000000" drools:selectable="true" sourceRef="processStartEvent" targetRef="_FD9F61FE-A2D0-43EF-84CD-4D1EDBE500B6"/>
+    <bpmn2:endEvent id="_143A5E03-2D84-44FE-B03F-3F6A7F867816" drools:bgcolor="#ff6347" drools:selectable="true" name="">
+      <bpmn2:incoming>_A008622B-217A-4109-91BF-2D879AD07903</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="_A008622B-217A-4109-91BF-2D879AD07903" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_FD9F61FE-A2D0-43EF-84CD-4D1EDBE500B6" targetRef="_143A5E03-2D84-44FE-B03F-3F6A7F867816"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_2iKidlYwEeWH_vp83kDU0A">
+    <bpmndi:BPMNPlane id="_2iKid1YwEeWH_vp83kDU0A" bpmnElement="CamelSQLProcess">
+      <bpmndi:BPMNShape id="_2iKieFYwEeWH_vp83kDU0A" bpmnElement="processStartEvent">
+        <dc:Bounds height="30.0" width="30.0" x="120.0" y="165.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_2iKieVYwEeWH_vp83kDU0A" bpmnElement="_FD9F61FE-A2D0-43EF-84CD-4D1EDBE500B6">
+        <dc:Bounds height="80.0" width="100.0" x="240.0" y="140.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_2iKielYwEeWH_vp83kDU0A" bpmnElement="_C63C8F09-1E36-4793-BF76-8E226AFF3268">
+        <di:waypoint xsi:type="dc:Point" x="135.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="290.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_2iKie1YwEeWH_vp83kDU0A" bpmnElement="_143A5E03-2D84-44FE-B03F-3F6A7F867816">
+        <dc:Bounds height="28.0" width="28.0" x="420.0" y="166.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_2iKifFYwEeWH_vp83kDU0A" bpmnElement="_A008622B-217A-4109-91BF-2D879AD07903">
+        <di:waypoint xsi:type="dc:Point" x="290.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="434.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_2iKifVYwEeWH_vp83kDU0A" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_C63C8F09-1E36-4793-BF76-8E226AFF3268" id="_2iKiflYwEeWH_vp83kDU0A">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_FD9F61FE-A2D0-43EF-84CD-4D1EDBE500B6" id="_2iKif1YwEeWH_vp83kDU0A">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_143A5E03-2D84-44FE-B03F-3F6A7F867816" id="_2iKigFYwEeWH_vp83kDU0A">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="processStartEvent" id="_2iLJgFYwEeWH_vp83kDU0A">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_A008622B-217A-4109-91BF-2D879AD07903" id="_2iLJgVYwEeWH_vp83kDU0A">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_2iKicFYwEeWH_vp83kDU0A</bpmn2:source>
+    <bpmn2:target>_2iKicFYwEeWH_vp83kDU0A</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/release/karaf/itests/camel/src/test/resources/org/jboss/integration/fuse/karaf/itest/workitem/BPMN2-CamelStreamProcess.bpmn2
+++ b/release/karaf/itests/camel/src/test/resources/org/jboss/integration/fuse/karaf/itest/workitem/BPMN2-CamelStreamProcess.bpmn2
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_Y0deAFbhEeWJnOPw_T9tDQ" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="_fileNameVarItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_payloadVarItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_pathVarItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__AFE9EBEF-429E-4170-8B7C-B6AE2498D50D_fileNameInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__AFE9EBEF-429E-4170-8B7C-B6AE2498D50D_payloadInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__AFE9EBEF-429E-4170-8B7C-B6AE2498D50D_pathInputXItem" structureRef="String"/>
+  <bpmn2:process id="camelStreamProcess" drools:packageName="org.jbpm" drools:version="1.0" name="camelStreamProcess" isExecutable="true">
+    <bpmn2:property id="fileNameVar" itemSubjectRef="_fileNameVarItem"/>
+    <bpmn2:property id="payloadVar" itemSubjectRef="_payloadVarItem"/>
+    <bpmn2:property id="pathVar" itemSubjectRef="_pathVarItem"/>
+    <bpmn2:startEvent id="processStartEvent" drools:bgcolor="#9acd32" drools:selectable="true" name="">
+      <bpmn2:outgoing>_E979F250-6744-464E-B443-E8DF27287800</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:task id="_AFE9EBEF-429E-4170-8B7C-B6AE2498D50D" drools:selectable="true" drools:taskName="CamelStream" name="Stream">
+      <bpmn2:incoming>_E979F250-6744-464E-B443-E8DF27287800</bpmn2:incoming>
+      <bpmn2:outgoing>_FBDFE69B-6F50-4A28-9C67-D1B9CA756372</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_Y0deAVbhEeWJnOPw_T9tDQ">
+        <bpmn2:dataInput id="_AFE9EBEF-429E-4170-8B7C-B6AE2498D50D_fileNameInputX" drools:dtype="String" itemSubjectRef="__AFE9EBEF-429E-4170-8B7C-B6AE2498D50D_fileNameInputXItem" name="fileName"/>
+        <bpmn2:dataInput id="_AFE9EBEF-429E-4170-8B7C-B6AE2498D50D_payloadInputX" drools:dtype="String" itemSubjectRef="__AFE9EBEF-429E-4170-8B7C-B6AE2498D50D_payloadInputXItem" name="payload"/>
+        <bpmn2:dataInput id="_AFE9EBEF-429E-4170-8B7C-B6AE2498D50D_pathInputX" drools:dtype="String" itemSubjectRef="__AFE9EBEF-429E-4170-8B7C-B6AE2498D50D_pathInputXItem" name="path"/>
+        <bpmn2:inputSet id="_Y0eFEFbhEeWJnOPw_T9tDQ">
+          <bpmn2:dataInputRefs>_AFE9EBEF-429E-4170-8B7C-B6AE2498D50D_fileNameInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_AFE9EBEF-429E-4170-8B7C-B6AE2498D50D_payloadInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_AFE9EBEF-429E-4170-8B7C-B6AE2498D50D_pathInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_Y0eFEVbhEeWJnOPw_T9tDQ"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_Y0eFElbhEeWJnOPw_T9tDQ">
+        <bpmn2:sourceRef>fileNameVar</bpmn2:sourceRef>
+        <bpmn2:targetRef>_AFE9EBEF-429E-4170-8B7C-B6AE2498D50D_fileNameInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_Y0eFE1bhEeWJnOPw_T9tDQ">
+        <bpmn2:sourceRef>payloadVar</bpmn2:sourceRef>
+        <bpmn2:targetRef>_AFE9EBEF-429E-4170-8B7C-B6AE2498D50D_payloadInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_Y0eFFFbhEeWJnOPw_T9tDQ">
+        <bpmn2:sourceRef>pathVar</bpmn2:sourceRef>
+        <bpmn2:targetRef>_AFE9EBEF-429E-4170-8B7C-B6AE2498D50D_pathInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:task>
+    <bpmn2:sequenceFlow id="_E979F250-6744-464E-B443-E8DF27287800" drools:bgcolor="#000000" drools:selectable="true" sourceRef="processStartEvent" targetRef="_AFE9EBEF-429E-4170-8B7C-B6AE2498D50D"/>
+    <bpmn2:endEvent id="_511AB3CD-FD10-4318-B019-CB90F0755103" drools:bgcolor="#ff6347" drools:selectable="true" name="">
+      <bpmn2:incoming>_FBDFE69B-6F50-4A28-9C67-D1B9CA756372</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="_FBDFE69B-6F50-4A28-9C67-D1B9CA756372" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_AFE9EBEF-429E-4170-8B7C-B6AE2498D50D" targetRef="_511AB3CD-FD10-4318-B019-CB90F0755103"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_Y0eFFVbhEeWJnOPw_T9tDQ">
+    <bpmndi:BPMNPlane id="_Y0eFFlbhEeWJnOPw_T9tDQ" bpmnElement="camelStreamProcess">
+      <bpmndi:BPMNShape id="_Y0eFF1bhEeWJnOPw_T9tDQ" bpmnElement="processStartEvent">
+        <dc:Bounds height="30.0" width="30.0" x="120.0" y="165.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_Y0eFGFbhEeWJnOPw_T9tDQ" bpmnElement="_AFE9EBEF-429E-4170-8B7C-B6AE2498D50D">
+        <dc:Bounds height="80.0" width="100.0" x="303.0" y="140.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_Y0eFGVbhEeWJnOPw_T9tDQ" bpmnElement="_E979F250-6744-464E-B443-E8DF27287800">
+        <di:waypoint xsi:type="dc:Point" x="135.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="353.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_Y0eFGlbhEeWJnOPw_T9tDQ" bpmnElement="_511AB3CD-FD10-4318-B019-CB90F0755103">
+        <dc:Bounds height="28.0" width="28.0" x="525.0" y="166.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_Y0eFG1bhEeWJnOPw_T9tDQ" bpmnElement="_FBDFE69B-6F50-4A28-9C67-D1B9CA756372">
+        <di:waypoint xsi:type="dc:Point" x="353.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="539.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_Y0eFHFbhEeWJnOPw_T9tDQ" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_AFE9EBEF-429E-4170-8B7C-B6AE2498D50D" id="_Y0eFHVbhEeWJnOPw_T9tDQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_511AB3CD-FD10-4318-B019-CB90F0755103" id="_Y0eFHlbhEeWJnOPw_T9tDQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_E979F250-6744-464E-B443-E8DF27287800" id="_Y0eFH1bhEeWJnOPw_T9tDQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="processStartEvent" id="_Y0eFIFbhEeWJnOPw_T9tDQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_FBDFE69B-6F50-4A28-9C67-D1B9CA756372" id="_Y0eFIVbhEeWJnOPw_T9tDQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_Y0deAFbhEeWJnOPw_T9tDQ</bpmn2:source>
+    <bpmn2:target>_Y0deAFbhEeWJnOPw_T9tDQ</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/release/karaf/itests/camel/src/test/resources/org/jboss/integration/fuse/karaf/itest/workitem/BPMN2-CamelXSLTProcess.bpmn2
+++ b/release/karaf/itests/camel/src/test/resources/org/jboss/integration/fuse/karaf/itest/workitem/BPMN2-CamelXSLTProcess.bpmn2
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_RGOJYFYEEeWH_vp83kDU0A" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="_templateNameVarItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_payloadVarItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_outputFileVarItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_outputVarItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__569A4D94-1DC3-4D1A-AC17-065D0A71B32F_templateNameInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__569A4D94-1DC3-4D1A-AC17-065D0A71B32F_payloadInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__569A4D94-1DC3-4D1A-AC17-065D0A71B32F_CamelXsltFileNameInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__569A4D94-1DC3-4D1A-AC17-065D0A71B32F_outputInputXItem" structureRef="String"/>
+  <bpmn2:process id="camelXSLTProcess" drools:packageName="org.jbpm" drools:version="1.0" name="camelXSLTProcess" isExecutable="true">
+    <bpmn2:property id="templateNameVar" itemSubjectRef="_templateNameVarItem"/>
+    <bpmn2:property id="payloadVar" itemSubjectRef="_payloadVarItem"/>
+    <bpmn2:property id="outputFileVar" itemSubjectRef="_outputFileVarItem"/>
+    <bpmn2:property id="outputVar" itemSubjectRef="_outputVarItem"/>
+    <bpmn2:startEvent id="_51FA1FC6-6B10-4253-A61A-0E8F5D6CF7E9" drools:bgcolor="#9acd32" drools:selectable="true" name="">
+      <bpmn2:outgoing>_F933D16D-7DFD-4AA3-82F9-E6C5C2B84F41</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:task id="_569A4D94-1DC3-4D1A-AC17-065D0A71B32F" drools:selectable="true"  drools:taskName="CamelXSLT" name="XSLT">
+      <bpmn2:incoming>_F933D16D-7DFD-4AA3-82F9-E6C5C2B84F41</bpmn2:incoming>
+      <bpmn2:outgoing>_42AEBE27-E618-4D11-A16C-6600944EA8AD</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_RGOJYVYEEeWH_vp83kDU0A">
+        <bpmn2:dataInput id="_569A4D94-1DC3-4D1A-AC17-065D0A71B32F_templateNameInputX" drools:dtype="String" itemSubjectRef="__569A4D94-1DC3-4D1A-AC17-065D0A71B32F_templateNameInputXItem" name="templateName"/>
+        <bpmn2:dataInput id="_569A4D94-1DC3-4D1A-AC17-065D0A71B32F_payloadInputX" drools:dtype="String" itemSubjectRef="__569A4D94-1DC3-4D1A-AC17-065D0A71B32F_payloadInputXItem" name="payload"/>
+        <bpmn2:dataInput id="_569A4D94-1DC3-4D1A-AC17-065D0A71B32F_CamelXsltFileNameInputX" drools:dtype="String" itemSubjectRef="__569A4D94-1DC3-4D1A-AC17-065D0A71B32F_CamelXsltFileNameInputXItem" name="CamelXsltFileName"/>
+        <bpmn2:dataInput id="_569A4D94-1DC3-4D1A-AC17-065D0A71B32F_outputInputX" drools:dtype="String" itemSubjectRef="__569A4D94-1DC3-4D1A-AC17-065D0A71B32F_outputInputXItem" name="output"/>
+        <bpmn2:inputSet id="_RGOJYlYEEeWH_vp83kDU0A">
+          <bpmn2:dataInputRefs>_569A4D94-1DC3-4D1A-AC17-065D0A71B32F_templateNameInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_569A4D94-1DC3-4D1A-AC17-065D0A71B32F_payloadInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_569A4D94-1DC3-4D1A-AC17-065D0A71B32F_CamelXsltFileNameInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_569A4D94-1DC3-4D1A-AC17-065D0A71B32F_outputInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_RGOwcFYEEeWH_vp83kDU0A"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_RGOwcVYEEeWH_vp83kDU0A">
+        <bpmn2:sourceRef>templateNameVar</bpmn2:sourceRef>
+        <bpmn2:targetRef>_569A4D94-1DC3-4D1A-AC17-065D0A71B32F_templateNameInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_RGOwclYEEeWH_vp83kDU0A">
+        <bpmn2:sourceRef>payloadVar</bpmn2:sourceRef>
+        <bpmn2:targetRef>_569A4D94-1DC3-4D1A-AC17-065D0A71B32F_payloadInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_RGOwc1YEEeWH_vp83kDU0A">
+        <bpmn2:sourceRef>outputFileVar</bpmn2:sourceRef>
+        <bpmn2:targetRef>_569A4D94-1DC3-4D1A-AC17-065D0A71B32F_CamelXsltFileNameInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_RGOwdFYEEeWH_vp83kDU0A">
+        <bpmn2:sourceRef>outputVar</bpmn2:sourceRef>
+        <bpmn2:targetRef>_569A4D94-1DC3-4D1A-AC17-065D0A71B32F_outputInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:task>
+    <bpmn2:sequenceFlow id="_F933D16D-7DFD-4AA3-82F9-E6C5C2B84F41" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_51FA1FC6-6B10-4253-A61A-0E8F5D6CF7E9" targetRef="_569A4D94-1DC3-4D1A-AC17-065D0A71B32F"/>
+    <bpmn2:endEvent id="_56DE08BA-CCD5-4692-86C5-E06E403DE5B3" drools:bgcolor="#ff6347" drools:selectable="true" name="">
+      <bpmn2:incoming>_42AEBE27-E618-4D11-A16C-6600944EA8AD</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="_42AEBE27-E618-4D11-A16C-6600944EA8AD" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_569A4D94-1DC3-4D1A-AC17-065D0A71B32F" targetRef="_56DE08BA-CCD5-4692-86C5-E06E403DE5B3"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_RGOwdVYEEeWH_vp83kDU0A">
+    <bpmndi:BPMNPlane id="_RGOwdlYEEeWH_vp83kDU0A" bpmnElement="camelXSLTProcess">
+      <bpmndi:BPMNShape id="_RGOwd1YEEeWH_vp83kDU0A" bpmnElement="_51FA1FC6-6B10-4253-A61A-0E8F5D6CF7E9">
+        <dc:Bounds height="30.0" width="30.0" x="120.0" y="150.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_RGOweFYEEeWH_vp83kDU0A" bpmnElement="_569A4D94-1DC3-4D1A-AC17-065D0A71B32F">
+        <dc:Bounds height="80.0" width="100.0" x="225.0" y="125.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_RGOweVYEEeWH_vp83kDU0A" bpmnElement="_F933D16D-7DFD-4AA3-82F9-E6C5C2B84F41">
+        <di:waypoint xsi:type="dc:Point" x="135.0" y="165.0"/>
+        <di:waypoint xsi:type="dc:Point" x="275.0" y="165.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_RGOwelYEEeWH_vp83kDU0A" bpmnElement="_56DE08BA-CCD5-4692-86C5-E06E403DE5B3">
+        <dc:Bounds height="28.0" width="28.0" x="390.0" y="151.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_RGOwe1YEEeWH_vp83kDU0A" bpmnElement="_42AEBE27-E618-4D11-A16C-6600944EA8AD">
+        <di:waypoint xsi:type="dc:Point" x="275.0" y="165.0"/>
+        <di:waypoint xsi:type="dc:Point" x="404.0" y="165.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_RGOwfFYEEeWH_vp83kDU0A" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_56DE08BA-CCD5-4692-86C5-E06E403DE5B3" id="_RGOwfVYEEeWH_vp83kDU0A">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_569A4D94-1DC3-4D1A-AC17-065D0A71B32F" id="_RGOwflYEEeWH_vp83kDU0A">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_51FA1FC6-6B10-4253-A61A-0E8F5D6CF7E9" id="_RGOwf1YEEeWH_vp83kDU0A">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_42AEBE27-E618-4D11-A16C-6600944EA8AD" id="_RGOwgFYEEeWH_vp83kDU0A">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_F933D16D-7DFD-4AA3-82F9-E6C5C2B84F41" id="_RGOwgVYEEeWH_vp83kDU0A">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_RGOJYFYEEeWH_vp83kDU0A</bpmn2:source>
+    <bpmn2:target>_RGOJYFYEEeWH_vp83kDU0A</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>


### PR DESCRIPTION
This pull request adds new tests for JBPM workitem in FUSE. There are tests for endpoints like SQL, XSLT and stream. Moreover, it is now possible to attach debugger on tests using karaf.debug.port parameter.