### PR TITLE
Update KIE  version to 6.3.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <version.wildfly.camel>2.3.0.redhat-621012</version.wildfly.camel>
 
         <!-- Internal dependencies -->
-        <version.org.kie>6.3.0-SNAPSHOT</version.org.kie>
+        <version.org.kie>6.3.1-SNAPSHOT</version.org.kie>
         <version.org.drools>${version.org.kie}</version.org.drools>
         <version.org.optaplanner>${version.org.kie}</version.org.optaplanner>
         <version.org.jbpm>${version.org.kie}</version.org.jbpm>


### PR DESCRIPTION
6.3.0.Final was released few days back, so 6.3.1-SNAPSHOT is the latest versions available.