### PR TITLE
Replace version.eap by version.org.jboss.as and upgrade version.redhat.eap to 6.4.4.GA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,6 @@
   <properties>
         <version.jboss.integration>1.2.0-SNAPSHOT</version.jboss.integration>
 
-        <!-- EAP early access -->
-        <version.eap>7.5.0.Final-redhat-20</version.eap>
-
         <!-- Perfectus managed versions -->
         <version.fuse.eap>6.2.1.redhat-071</version.fuse.eap>
         <version.fuse.patch>1.6.2</version.fuse.patch>
@@ -107,10 +104,10 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered
           resources, i.e. build is platform dependent! -->
         <version.org.jboss.as.console>1.5.4.Final</version.org.jboss.as.console>
-        <version.org.jboss.as>7.2.0.Final</version.org.jboss.as>
-        <version.redhat.eap6.bom>6.3.0.GA</version.redhat.eap6.bom>
+        <version.org.jboss.as>7.5.4.Final-redhat-4</version.org.jboss.as>
+        <version.redhat.eap6.bom>6.4.4.GA</version.redhat.eap6.bom>
         <!-- This version is only used as a prefix for a jar included in release modules -->
-        <version.redhat.eap6>6.3</version.redhat.eap6>
+        <version.redhat.eap6>6.4</version.redhat.eap6>
         <version.redhat.eap6.minor>0.GA</version.redhat.eap6.minor>
         <version.org.fusesource.hawtdispatch>1.18</version.org.fusesource.hawtdispatch>
         <version.org.fusesource.hawtbuf>1.9</version.org.fusesource.hawtbuf>

--- a/release/eap/itests/pom.xml
+++ b/release/eap/itests/pom.xml
@@ -214,7 +214,7 @@
                                 <artifactItem>
                                     <groupId>org.jboss.as</groupId>
                                     <artifactId>jboss-as-dist</artifactId>
-                                    <version>${version.eap}</version>
+                                    <version>${version.org.jboss.as}</version>
                                     <type>zip</type>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}</outputDirectory>


### PR DESCRIPTION
This is for sorting the eap version in the pom.
I think the correct eap version is 6.4.4.GA at the moment.

Please review this, hopefully this can catch the next release of product release.