### PR TITLE
Update drools version to 6.3.x to be more meaningful to user

### DIFF
--- a/release/karaf/fuse-integration-karaf-distro/README_FUSE_INTEGRATION.md
+++ b/release/karaf/fuse-integration-karaf-distro/README_FUSE_INTEGRATION.md
@@ -11,7 +11,7 @@ Camel components used in kie: kie-camel and jbpm-workitem-camel components
 
 Requirements
 ============
-DROOLS_VERSION --> ${DROOLS_VERSION}
+DROOLS_VERSION --> 6.3.x
 
 1.  Download the Fuse distribution that is aligned with the version of fuse-integration:
     `


### PR DESCRIPTION
Update the drools_version to 6.3.x to be more meaningful