### PR TITLE
New test scenario: Use Camel route to execute rules imported by GAV.

### DIFF
--- a/release/karaf/itests/camel-module/pom.xml
+++ b/release/karaf/itests/camel-module/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>fuse-integration-karaf-tests</artifactId>
+    <groupId>org.jboss.integration.fuse</groupId>
+    <version>1.2.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>kie-camel-karaf-itest-module</artifactId>
+
+
+</project>

--- a/release/karaf/itests/camel-module/src/main/resources/META-INF/kmodule.xml
+++ b/release/karaf/itests/camel-module/src/main/resources/META-INF/kmodule.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kmodule xmlns="http://jboss.org/kie/6.0.0/kmodule">
+  <kbase name="kieModuleKieBaseDrinkGav" packages="org.jboss.integration.fuse.karaf.itest.kiecamel.module.drl" default="true">
+    <ksession name="kieModuleKieSessionDrinkGav" type="stateless"/>
+  </kbase>
+</kmodule>

--- a/release/karaf/itests/camel-module/src/main/resources/org/jboss/integration/fuse/karaf/itest/kiecamel/module/drl/personRules.drl
+++ b/release/karaf/itests/camel-module/src/main/resources/org/jboss/integration/fuse/karaf/itest/kiecamel/module/drl/personRules.drl
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2012 Red Hat
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.jboss.integration.fuse.karaf.itest.kiecamel.module.drl;
+
+declare Person
+    name : String
+    age: int
+    canDrink: boolean
+end
+
+rule "CanDrink"
+when
+    p : Person( age >= 21 )
+then
+	p.setCanDrink(true);
+end

--- a/release/karaf/itests/camel/src/test/java/org/jboss/integration/fuse/karaf/itest/KarafConfigUtil.java
+++ b/release/karaf/itests/camel/src/test/java/org/jboss/integration/fuse/karaf/itest/KarafConfigUtil.java
@@ -30,6 +30,7 @@ import static org.jboss.integration.fuse.karaf.itest.FeatureConstants.DROOLS_DT_
 import static org.jboss.integration.fuse.karaf.itest.FeatureConstants.DROOLS_FEATURE_ARTIFACT_ID;
 import static org.jboss.integration.fuse.karaf.itest.FeatureConstants.DROOLS_FEATURE_GROUP_ID;
 import static org.jboss.integration.fuse.karaf.itest.FeatureConstants.H2_FEATURE_NAME;
+import static org.jboss.integration.fuse.karaf.itest.FeatureConstants.KIE_CI_FEATURE_NAME;
 import static org.jboss.integration.fuse.karaf.itest.FeatureConstants.HIBERNATE_FEATURE_NAME;
 import static org.jboss.integration.fuse.karaf.itest.FeatureConstants.INTEG_PACK_FEATURE_ARTIFACT_ID;
 import static org.jboss.integration.fuse.karaf.itest.FeatureConstants.INTEG_PACK_FEATURE_GROUP_ID;
@@ -165,7 +166,7 @@ public class KarafConfigUtil {
         
         options.add(features(maven().groupId(DROOLS_FEATURE_GROUP_ID).artifactId(DROOLS_FEATURE_ARTIFACT_ID)
                                         .versionAsInProject().type("xml").classifier("features"),
-                                JNDI_FEATURE_NAME, H2_FEATURE_NAME, HIBERNATE_FEATURE_NAME,
+                                JNDI_FEATURE_NAME, H2_FEATURE_NAME, HIBERNATE_FEATURE_NAME, KIE_CI_FEATURE_NAME,
                                 JBPM_FEATURE_NAME, DROOLS_DT_FEATURE_NAME, KIE_SPRING_FEATURE_NAME,
                                 KIE_ARIES_BLUEPRINT_FEATURE_NAME));
         options.add(features(maven().groupId(INTEG_PACK_FEATURE_GROUP_ID).artifactId(INTEG_PACK_FEATURE_ARTIFACT_ID)

--- a/release/karaf/itests/camel/src/test/java/org/jboss/integration/fuse/karaf/itest/kiecamel/KieCamelBlueprintGavTest.java
+++ b/release/karaf/itests/camel/src/test/java/org/jboss/integration/fuse/karaf/itest/kiecamel/KieCamelBlueprintGavTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2015 Red Hat Inc. and/or its affiliates and other contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.integration.fuse.karaf.itest.kiecamel;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import org.jboss.integration.fuse.karaf.itest.kiecamel.proxy.AgeVerificationServiceGav;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.api.KieBase;
+import org.kie.api.definition.type.FactType;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.KieSession;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.apache.camel.CamelContext;
+
+import javax.inject.Inject;
+import org.apache.camel.component.bean.PojoProxyHelper;
+import org.jboss.integration.fuse.karaf.itest.KarafConfigUtil;
+import org.jboss.integration.fuse.karaf.itest.kiecamel.proxy.AgeVerificationService;
+import org.jboss.integration.fuse.karaf.itest.kiecamel.tools.PersonFactoryGav;
+import org.ops4j.pax.exam.Configuration;
+import org.osgi.service.blueprint.container.BlueprintContainer;
+
+/**
+ * Test scenarion: Insert facts and execute rules locally in Fuse using a Camel route.
+ * Rule definitions are resolved as KIE artifacts using Maven.
+ */
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class KieCamelBlueprintGavTest {
+
+    @Inject
+    private CamelContext camelContext;
+
+    @Inject
+    private KieBase kieBase;
+
+    @Configuration
+    public static Option[] configure() {
+        return KarafConfigUtil.karafConfiguration();
+    }
+
+    @Test(timeout = 60000)
+    public void testOldPerson() throws Exception {
+        FactType personType = kieBase.getFactType("org.jboss.integration.fuse.karaf.itest.kiecamel.module.drl", "Person");
+        final AgeVerificationServiceGav service = getAgeVerificationProxy();
+        final Object verifiedPerson = service.verifyAge(PersonFactoryGav.createOldPerson(personType));
+
+        boolean canDrink = (Boolean) personType.get(verifiedPerson, "canDrink");
+
+        assertTrue(canDrink);
+    }
+
+    @Test(timeout = 60000)
+    public void testYoungPerson() throws Exception {
+        FactType personType = kieBase.getFactType("org.jboss.integration.fuse.karaf.itest.kiecamel.module.drl", "Person");
+        final AgeVerificationServiceGav service = getAgeVerificationProxy();
+        final Object verifiedPerson = service.verifyAge(PersonFactoryGav.createYoungPerson(personType));
+
+        Boolean canDrink = (Boolean) personType.get(verifiedPerson, "canDrink");
+
+        assertFalse(canDrink);
+    }
+
+    private AgeVerificationServiceGav getAgeVerificationProxy() throws Exception {
+        // need to use PojoProxyHelper to avoid sending BeanInvocation object as payload
+        return PojoProxyHelper.createProxy(camelContext.getEndpoint("direct://startAgeVerificationGav"),
+                AgeVerificationServiceGav.class);
+    }
+}

--- a/release/karaf/itests/camel/src/test/java/org/jboss/integration/fuse/karaf/itest/kiecamel/proxy/AgeVerificationServiceGav.java
+++ b/release/karaf/itests/camel/src/test/java/org/jboss/integration/fuse/karaf/itest/kiecamel/proxy/AgeVerificationServiceGav.java
@@ -1,0 +1,8 @@
+package org.jboss.integration.fuse.karaf.itest.kiecamel.proxy;
+
+/**
+ * Created by jpetrlik on 11/11/15.
+ */
+public interface AgeVerificationServiceGav {
+    Object verifyAge(Object person);
+}

--- a/release/karaf/itests/camel/src/test/java/org/jboss/integration/fuse/karaf/itest/kiecamel/tools/PersonFactoryGav.java
+++ b/release/karaf/itests/camel/src/test/java/org/jboss/integration/fuse/karaf/itest/kiecamel/tools/PersonFactoryGav.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012 Red Hat
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.jboss.integration.fuse.karaf.itest.kiecamel.tools;
+
+import org.kie.api.definition.type.FactType;
+
+public class PersonFactoryGav {
+
+    private PersonFactoryGav() {
+    }
+
+    public static Object createOldPerson(FactType personType) throws IllegalAccessException, InstantiationException {
+
+        Object person = personType.newInstance();
+        personType.set(person, "name", "Old person");
+        personType.set(person, "age", 21);
+
+        return person;
+    }
+
+    public static Object createYoungPerson(FactType personType) throws IllegalAccessException, InstantiationException {
+        Object person = personType.newInstance();
+        personType.set(person, "name", "Young person");
+        personType.set(person, "age", 18);
+
+        return person;
+    }
+}

--- a/release/karaf/itests/camel/src/test/resources/OSGI-INF/blueprint/camel-context.xml
+++ b/release/karaf/itests/camel/src/test/resources/OSGI-INF/blueprint/camel-context.xml
@@ -39,6 +39,22 @@
             </choice>
         </route>
 
+        <route trace="true" id="testRouteGav">
+            <description>This route is for kie-camel containing facts imported by releaseId.
+            </description>
+            <from uri="direct://startAgeVerificationGav"/>
+            <to uri="kie:kieModuleKieSessionDrinkGav?action=insertBody" id="AgeVerificationGav"/>
+            <choice>
+                <when id="CanDrinkGav">
+                    <simple>${body.canDrink}</simple>
+                    <log logName="Bar" message="Person ${body.name} can go to the bar"/>
+                </when>
+                <otherwise>
+                    <log logName="Home" message="Person ${body.name} is staying home"/>
+                </otherwise>
+            </choice>
+        </route>
+
         <!-- Decision Table Routes -->
         <route trace="false" id="testRouteDecisionTable">
             <description>This route shows an example of passing (inserting) the Body of the message as a POJO to Drools

--- a/release/karaf/itests/camel/src/test/resources/OSGI-INF/blueprint/kie.xml
+++ b/release/karaf/itests/camel/src/test/resources/OSGI-INF/blueprint/kie.xml
@@ -17,4 +17,24 @@
     </kie:kbase>
   </kie:kmodule>
 
+  <kie:releaseId id="kjar-gav" groupId="org.jboss.integration.fuse" artifactId="kie-camel-karaf-itest-module" version="1.2.0-SNAPSHOT"/>
+  <kie:kcontainer-ref id="kjar-container" releaseId="kjar-gav"/>
+
+  <bean id="kie-services"
+        class="org.kie.api.KieServices.Factory"
+        factory-method="get"/>
+
+  <bean id="kieModuleKieBaseDrinkGav"
+        factory-ref="kjar-container"
+        factory-method="getKieBase">
+    <argument value="kieModuleKieBaseDrinkGav"/>
+  </bean>
+  <bean id="kieModuleKieSessionDrinkGav"
+        factory-ref="kjar-container"
+        factory-method="newStatelessKieSession">
+    <argument value="kieModuleKieSessionDrinkGav"/>
+  </bean>
+
+  <service id="kieModuleKieBaseDrinkGavService" ref="kieModuleKieBaseDrinkGav" interface="org.kie.api.KieBase"/>
+
 </blueprint>

--- a/release/karaf/itests/pom.xml
+++ b/release/karaf/itests/pom.xml
@@ -28,6 +28,7 @@
     <description>Fuse Integration Release Karaf Tests</description>
 
     <modules>
+       <module>camel-module</module>
        <module>camel</module>
        <module>switchyard</module>
        <module>drools</module>


### PR DESCRIPTION
Insert facts and execute rules locally in Karaf using a Camel route and kie-camel component.  Rule definitions are resolved as KIE artifacts using Maven. Please cherry pick also into 1.2.x branch.