### PR TITLE
[ENTESB-4755] fix versions for test resources + re-enable camel tests

### DIFF
--- a/release/karaf/itests/camel-module/pom.xml
+++ b/release/karaf/itests/camel-module/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>fuse-integration-karaf-tests</artifactId>
     <groupId>org.jboss.integration.fuse</groupId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/release/karaf/itests/camel/pom.xml
+++ b/release/karaf/itests/camel/pom.xml
@@ -139,6 +139,14 @@
             <artifactId>h2</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <!-- Temporary workaround. This should be removed once the Karaf is properly configured with the remote repos,
+             so that it can download the kie-ci-osgi itself (instead of relying on the outer Maven test build). -->
+        <dependency>
+            <groupId>org.kie</groupId>
+            <artifactId>kie-ci-osgi</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
     <build>

--- a/release/karaf/itests/camel/src/test/filtered-resources/OSGI-INF/blueprint/kie.xml
+++ b/release/karaf/itests/camel/src/test/filtered-resources/OSGI-INF/blueprint/kie.xml
@@ -17,7 +17,7 @@
     </kie:kbase>
   </kie:kmodule>
 
-  <kie:releaseId id="kjar-gav" groupId="org.jboss.integration.fuse" artifactId="kie-camel-karaf-itest-module" version="1.2.0-SNAPSHOT"/>
+  <kie:releaseId id="kjar-gav" groupId="org.jboss.integration.fuse" artifactId="kie-camel-karaf-itest-module" version="${project.version}"/>
   <kie:kcontainer-ref id="kjar-container" releaseId="kjar-gav"/>
 
   <bean id="kie-services"

--- a/release/karaf/itests/pom.xml
+++ b/release/karaf/itests/pom.xml
@@ -29,7 +29,7 @@
 
     <modules>
        <module>camel-module</module>
-       <!--module>camel</module-->
+       <module>camel</module>
        <module>switchyard</module>
        <module>drools</module>
     </modules>


### PR DESCRIPTION
 * adding the dependency on kie-ci-osgi is just temporary workaround.
   The tests need to updated to contain specific config for Karaf
   with remote repos that host the artifacts like kie-ci-osgi, so
   that Karaf can download them at runtime during the test execution