### PR TITLE
To fix ENTESB-4719 on master branch

### DIFF
--- a/camel/pom.xml
+++ b/camel/pom.xml
@@ -26,101 +26,17 @@
     <packaging>pom</packaging>
     <dependencyManagement>
        <dependencies>
-   <dependency>
-        <groupId>org.apache.cxf</groupId>
-        <artifactId>cxf-core</artifactId>
-        <version>${version.org.apache.cxf}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId>
-        <artifactId>cxf-rt-rs-security-oauth</artifactId>
-        <version>${version.org.apache.cxf}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId>
-        <artifactId>cxf-rt-features-clustering</artifactId>
-        <version>${version.org.apache.cxf}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId>
-        <artifactId>cxf-rt-frontend-simple</artifactId>
-        <version>${version.org.apache.cxf}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId>
-        <artifactId>cxf-rt-bindings-soap</artifactId>
-        <version>${version.org.apache.cxf}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId>
-        <artifactId>cxf-rt-databinding-jaxb</artifactId>
-        <version>${version.org.apache.cxf}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.woodstox</groupId>
-        <artifactId>stax2-api</artifactId>
-        <version>3.1.1</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId>
-        <artifactId>cxf-rt-frontend-jaxws</artifactId>
-        <version>${version.org.apache.cxf}</version>
-	<exclusions>
-           <exclusion>
-        <groupId>asm</groupId>
-        <artifactId>asm</artifactId>          
-           </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId>
-        <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-        <version>${version.org.apache.cxf}</version>
-	<exclusions>
-           <exclusion>
-        <groupId>asm</groupId>
-        <artifactId>asm</artifactId>          
-           </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId>
-        <artifactId>cxf-rt-bindings-xml</artifactId>
-        <version>${version.org.apache.cxf}</version>
-      </dependency>
-      <!--dependency>
-        <groupId>org.eclipse.jdt.core.compiler</groupId>
-        <artifactId>ecj</artifactId>
-        <version>4.4.2</version>
-      </dependency-->
-      <dependency>
-        <groupId>org.apache.cxf</groupId>
-        <artifactId>cxf-rt-transports-http</artifactId>
-        <version>${version.org.apache.cxf}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId>
-        <artifactId>cxf-rt-transports-http-jetty</artifactId>
-        <version>${version.org.apache.cxf}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.cxf</groupId>
-        <artifactId>cxf-rt-ws-addr</artifactId>
-        <version>${version.org.apache.cxf}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId>
-        <artifactId>cxf-rt-ws-policy</artifactId>
-        <version>${version.org.apache.cxf}</version>
-      </dependency>
+          <dependency>
+            <groupId>org.jboss.fuse.bom</groupId>
+            <artifactId>jboss-fuse-parent</artifactId>
+            <version>${version.fuse.eap}</version>
+            <type>pom</type>
+            <scope>import</scope>
+         </dependency>
        </dependencies>
     </dependencyManagement>
     <name>Fuse Integration: Camel: Parent</name>
     <description>Fuse BXMS Integration Camel Parent</description>
-    <properties>
-	<version.org.apache.cxf>3.0.4</version.org.apache.cxf>
-    </properties>
     <modules>
         <module>kie-camel</module>
         <module>jbpm-workitems-camel</module>


### PR DESCRIPTION
This is for fixing Entesb-4719. However this is only partially fixed the problem.
cxf dependencies versions in quickstarts are still different from the dependencies in other modules.
This probably have to defer to future when switchyard project, droolsjbpm project and Fuse project use the same cxf dependencies.
This PR will reduce the cxf multiple versions and make it use supported ones.