### PR TITLE
switchyard-itests: use INFO logging level by default to decrease log size

### DIFF
--- a/release/karaf/itests/switchyard/src/test/java/org/switchyard/karaf/test/quickstarts/AbstractQuickstartTest.java
+++ b/release/karaf/itests/switchyard/src/test/java/org/switchyard/karaf/test/quickstarts/AbstractQuickstartTest.java
@@ -143,7 +143,7 @@ public abstract class AbstractQuickstartTest {
                         .name("Apache Karaf").unpackDirectory(new File("target/karaf/" + featureName))
                         .useDeployFolder(false),
                 //keepRuntimeFolder(), // this could leave behind lots of cruft
-                logLevel(LogLevel.DEBUG),
+                logLevel(LogLevel.INFO),
                 configureConsole().ignoreLocalConsole().ignoreRemoteShell(),
                 editConfigurationFileExtend("etc/config.properties", "org.osgi.framework.system.packages.extra",
                         "sun.misc"),


### PR DESCRIPTION
 * this simple change decreases the overall log output size from
   ~60MiB to ~10MiB