### PR TITLE
ENTESB-4872 Fix error on pom.xml of rules-loading quickstart

### DIFF
--- a/quickstarts/switchyard-rules-loading/pom.xml
+++ b/quickstarts/switchyard-rules-loading/pom.xml
@@ -229,7 +229,6 @@
                	<skip>true</skip>
                </configuration>
 			</plugin>
-		</plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
@@ -244,6 +243,7 @@
                     </execution>
                 </executions>
             </plugin>
+		</plugins>
 	</build>
 
 	<repositories>


### PR DESCRIPTION
https://issues.jboss.org/browse/ENTESB-4872