### PR TITLE
[ENTESB-4920] fix Java 8 test fails, use ECJ compatible with Java 8

### DIFF
--- a/quickstarts/switchyard-bpm-service/pom.xml
+++ b/quickstarts/switchyard-bpm-service/pom.xml
@@ -102,6 +102,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- TODO: remove this override once SwitchYard upgrades to ip-bom 6.0.3.Final -->
+            <dependency>
+                <groupId>org.eclipse.jdt.core.compiler</groupId>
+                <artifactId>ecj</artifactId>
+                <version>4.4.2</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <repositories>

--- a/quickstarts/switchyard-demo-library/pom.xml
+++ b/quickstarts/switchyard-demo-library/pom.xml
@@ -98,6 +98,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- TODO: remove this override once SwitchYard upgrades to ip-bom 6.0.3.Final -->
+            <dependency>
+                <groupId>org.eclipse.jdt.core.compiler</groupId>
+                <artifactId>ecj</artifactId>
+                <version>4.4.2</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <repositories>


### PR DESCRIPTION
 * this is a temporary fix until SY upgrades to ip-bom 6.0.3.Final
   (it currently brings in ECJ 4.3.x which is not Java 8 compatible)