### PR TITLE
ENTEST-5159 Remove the backward-compat module's reference 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -673,16 +673,6 @@
                 <version>${version.switchyard}</version>
             </dependency>
             <dependency>
-                <groupId>org.switchyard.components</groupId>
-                <artifactId>switchyard-component-common-knowledge</artifactId>
-                <version>${version.switchyard}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.switchyard.components</groupId>
-                <artifactId>switchyard-component-rules</artifactId>
-                <version>${version.switchyard}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.jboss.integration.fuse</groupId>
                 <artifactId>kie-camel</artifactId>
                 <version>${project.version}</version>

--- a/quickstarts/switchyard-demo-library/pom.xml
+++ b/quickstarts/switchyard-demo-library/pom.xml
@@ -111,11 +111,11 @@
             <artifactId>switchyard-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.switchyard.components</groupId>
+            <groupId>org.jboss.integration.fuse</groupId>
             <artifactId>switchyard-component-bpm</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.switchyard.components</groupId>
+            <groupId>org.jboss.integration.fuse</groupId>
             <artifactId>switchyard-component-rules</artifactId>
         </dependency>
         <dependency>

--- a/quickstarts/switchyard-rules-loading/pom.xml
+++ b/quickstarts/switchyard-rules-loading/pom.xml
@@ -54,7 +54,7 @@
 			<artifactId>switchyard-api</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.switchyard.components</groupId>
+			<groupId>org.jboss.integration.fuse</groupId>
 			<artifactId>switchyard-component-rules</artifactId>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
There were still backward-compat modules are referenced by other module so it caused duplicate drools boms and artifacts. 
This PR is to remove the rest of the dependencies on the old backward-compat.