### PR TITLE
ENTESB-5159 Remove the old switchyard-component-common-knowledge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -547,16 +547,6 @@
                 <version>${version.switchyard}</version>
             </dependency>
             <dependency>
-                <groupId>org.switchyard.components</groupId>
-                <artifactId>switchyard-component-common-knowledge</artifactId>
-                <version>${version.switchyard}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.switchyard.components</groupId>
-                <artifactId>switchyard-component-rules</artifactId>
-                <version>${version.switchyard}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.jboss.integration.fuse</groupId>
                 <artifactId>kie-camel</artifactId>
                 <version>${project.version}</version>


### PR DESCRIPTION
There were still backward-compat modules are referenced by other module so it caused duplicate drools boms and artifacts. 
This PR is to remove the rest of the dependencies on the old backward-compat.