### PR TITLE
ENTESB-5643 Temporarily disable eap distro module 

### DIFF
--- a/release/pom.xml
+++ b/release/pom.xml
@@ -29,7 +29,7 @@
         <version.distro>2.0</version.distro>
     </properties>
     <modules>
-        <module>eap</module>
+        <!--module>eap</module-->
         <module>karaf</module>
     </modules>
 </project>


### PR DESCRIPTION
This is because  it can't build with the EAP 6.4.7, and we need to release intpack on karaf distro based on Fuse 6.2.1 R2 asap as discussed in pm list.
We can surely  recover the eap module build after we move to Fuse 6.2.1 R3 or fix that issue. 

