### PR TITLE
ENTESB-5708 Feature "fuse-bxms-switchyard-common-knowledge" should install bundle "switchyard-component-common"

### DIFF
--- a/karaf/karaf-features/src/main/resources/features.xml
+++ b/karaf/karaf-features/src/main/resources/features.xml
@@ -11,6 +11,7 @@
         <feature version="${karaf.version.org.kie}">kie-ci</feature>
         <feature version="${karaf.version.org.kie}">jbpm-executor</feature>
         <feature version="${karaf.version.org.kie}">kie-remote-client</feature>
+        <bundle>mvn:org.switchyard.components/switchyard-component-common/${version.switchyard}</bundle>
         <bundle>mvn:org.jboss.integration.fuse/switchyard-component-common-knowledge/${project.version}</bundle>
         <bundle>mvn:org.jboss.integration.fuse/switchyard-component-common-knowledge-osgi/${project.version}</bundle>
     </feature>


### PR DESCRIPTION
https://issues.jboss.org/browse/ENTESB-5708