### PR TITLE
[1.4.x][ENTESB-5152] fix jbpm-workitems-camel-qs: add slf4j package import

### DIFF
--- a/quickstarts/jbpm-workitems-camel/pom.xml
+++ b/quickstarts/jbpm-workitems-camel/pom.xml
@@ -268,7 +268,8 @@
                             org.kie.api.runtime.rule;version="[6.0,7)",
                             org.kie.api.runtime.process;version="[6.0,7)",
                             org.kie.internal;version="[6.0,7)", javax.servlet, javax.servlet.http,
-                            org.jbpm.process.workitem.camel 
+                            org.jbpm.process.workitem.camel,
+                            org.slf4j
                         </Import-Package>
                         <Private-Package>
                             org.jboss.integration.fuse.quickstarts.jbpm.workitems.camel 

--- a/quickstarts/jbpm-workitems-camel/src/main/java/org/jboss/integration/fuse/quickstarts/jbpm/workitems/camel/ApplicationServlet.java
+++ b/quickstarts/jbpm-workitems-camel/src/main/java/org/jboss/integration/fuse/quickstarts/jbpm/workitems/camel/ApplicationServlet.java
@@ -119,8 +119,9 @@ public class ApplicationServlet extends HttpServlet {
         PrintWriter out = resp.getWriter();
         out.println("<h1>Accepted Applications</h1>");
         out.println("<ul>");
-        BufferedReader reader = new BufferedReader(new FileReader(new File(tempDir.getAbsolutePath() + File.separatorChar
-                + ACCEPTED_APPS_FILENAME)));
+        File acceptedAppsFile = new File(tempDir.getAbsolutePath() + File.separatorChar + ACCEPTED_APPS_FILENAME);
+        acceptedAppsFile.createNewFile();
+        BufferedReader reader = new BufferedReader(new FileReader(acceptedAppsFile));
         String line;
         while ((line = reader.readLine()) != null) {
             out.println("<li>" + line + "</li>");
@@ -129,8 +130,9 @@ public class ApplicationServlet extends HttpServlet {
         out.println("</ul>");
         out.println("<br>");
         out.println("<h1>Rejected Applications</h1>");
-        reader = new BufferedReader(new FileReader(new File(tempDir.getAbsolutePath() + File.separatorChar
-                + REJECTED_APPS_FILENAME)));
+        File rejectedAppsFile = new File(tempDir.getAbsolutePath() + File.separatorChar + REJECTED_APPS_FILENAME);
+        rejectedAppsFile.createNewFile();
+        reader = new BufferedReader(new FileReader(rejectedAppsFile));
         while ((line = reader.readLine()) != null) {
             out.println("<li>" + line + "</li>");
         }


### PR DESCRIPTION
 * also change the code a bit to make sure the accepted/rejected
   file always exists, otherwise the FileReader fails on
   non-existing file

@cunningt could you please review and merge?