### PR TITLE
reverted upgrade of jboss-IP-Bom

### DIFF
--- a/fuse-integration-bom/pom.xml
+++ b/fuse-integration-bom/pom.xml
@@ -19,7 +19,7 @@
         <groupId>org.jboss.integration-platform</groupId>
         <artifactId>jboss-integration-platform-parent</artifactId>
         <!-- Keep in sync with property <version.org.jboss.integration-platform> -->
-        <version>6.0.7.Final</version>
+        <version>6.0.6.Final</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.integration.fuse</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <groupId>org.jboss.integration-platform</groupId>
         <artifactId>jboss-integration-platform-parent</artifactId>
         <!-- Keep in sync with property <version.org.jboss.integration-platform> -->
-        <version>6.0.7.Final</version>
+        <version>6.0.6.Final</version>
     </parent>
     <groupId>org.jboss.integration.fuse</groupId>
     <artifactId>fuse-integration-project</artifactId>
@@ -67,7 +67,7 @@
         
         <!-- Internal dependencies -->
         <version.org.kie>6.4.1-SNAPSHOT</version.org.kie>
-        <version.org.jboss.integration-platform>6.0.7.Final</version.org.jboss.integration-platform>
+        <version.org.jboss.integration-platform>6.0.6.Final</version.org.jboss.integration-platform>
         <version.org.apache.geronimo.specs>1.0</version.org.apache.geronimo.specs>
         <version.org.ops4j.pax.url>2.2.0</version.org.ops4j.pax.url>
         <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>

--- a/quickstarts/blueprint-camel-drools-decision-table/pom.xml
+++ b/quickstarts/blueprint-camel-drools-decision-table/pom.xml
@@ -48,7 +48,7 @@
         <maven.surefire.plugin.version>2.19.1</maven.surefire.plugin.version>
         <version.org.kie>6.4.1-SNAPSHOT</version.org.kie>
         <version.apache.camel>2.15.1.redhat-621117</version.apache.camel>
-        <version.org.jboss.integration-platform>6.0.7.Final</version.org.jboss.integration-platform>
+        <version.org.jboss.integration-platform>6.0.6.Final</version.org.jboss.integration-platform>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/quickstarts/spring-camel-drools-decision-table/pom.xml
+++ b/quickstarts/spring-camel-drools-decision-table/pom.xml
@@ -50,7 +50,7 @@
         <maven.surefire.plugin.version>2.19.1</maven.surefire.plugin.version>
         <version.org.kie>6.4.1-SNAPSHOT</version.org.kie>
         <deploy.skip>true</deploy.skip>
-        <version.org.jboss.integration-platform>6.0.7.Final</version.org.jboss.integration-platform>
+        <version.org.jboss.integration-platform>6.0.6.Final</version.org.jboss.integration-platform>
         <wildfly.port>9999</wildfly.port>
         <version.wildfly.maven>1.0.2.Final</version.wildfly.maven>
         <bundle.symbolic.name>${project.groupId}.spring.camel.drools.decision.table</bundle.symbolic.name>


### PR DESCRIPTION
The upgrade tp jboss-ip-bom 6.0.7.Final has to be reverted as it will upgrade XStream to 1.4.9 as this
contains Java 8 (non-backwards compatibile) code, which causes Webpshere to prevent the BPMS
webservice from deploying. 