### PR TITLE
ENTESB-5928 Jar with quickstarts for int. pack karaf distribution is empty

### DIFF
--- a/quickstarts/fuse-integration-quickstarts-karaf/pom.xml
+++ b/quickstarts/fuse-integration-quickstarts-karaf/pom.xml
@@ -22,7 +22,7 @@
         <relativePath>../</relativePath>
     </parent>
     <artifactId>fuse-integration-quickstarts-karaf</artifactId>
-    <packaging>jar</packaging>
+    <packaging>pom</packaging>
     <name>Fuse Integration: Quickstarts: Karaf: Assembly Distro</name>
     <description>Fuse Integration: Quickstarts: Karaf: Assembly Distro</description>
     <build>


### PR DESCRIPTION
https://issues.jboss.org/browse/ENTESB-5928