### PR TITLE
Add the correct markdown extension to README in installer zip.

### DIFF
--- a/release/eap/installer-zip/assembly.xml
+++ b/release/eap/installer-zip/assembly.xml
@@ -25,7 +25,7 @@
         <file>
             <source>${project.build.directory}/README_FUSE_INTEGRATION.md</source>
             <outputDirectory>/</outputDirectory>
-            <destName>README</destName>
+            <destName>README.md</destName>
         </file>
     </files>
 


### PR DESCRIPTION
Minor fix to "README" contained within the installer zip to have the correct extension, can you please cherry-pick this to 1.4.x too?